### PR TITLE
Merge rules as argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,3 +101,13 @@ path. Full absolute paths can be used too:
 
    # Use relese-schema.json using absolute path
    ocdsmerge.merge(releases, '/some/full/path/release-schema.json')
+
+Using processed schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   # process schema
+   rules = ocdsmerge.process_schema('release-schema.json')
+   # merge releases
+   ocdsmerge.merge(releases, merge_rules=rules)

--- a/ocdsmerge/__init__.py
+++ b/ocdsmerge/__init__.py
@@ -1,1 +1,2 @@
-from .merge import merge, merge_versioned  # noqa
+from .merge import merge, merge_versioned,\
+    process_schema  # noqa

--- a/ocdsmerge/merge.py
+++ b/ocdsmerge/merge.py
@@ -156,10 +156,11 @@ def process_flattened(flattened):
     return processed
 
 
-def merge(releases, schema=None):
+def merge(releases, schema=None, merge_rules=None):
     ''' Takes a list of releases and merge them making a
     compiledRelease suitible for an OCDS Record '''
-    merge_rules = process_schema(schema)
+    if not merge_rules:
+        merge_rules = process_schema(schema)
     merged = collections.OrderedDict({("tag",): ['compiled']})
     for release in sorted(releases, key=lambda rel: rel["date"]):
         release = release.copy()
@@ -184,10 +185,11 @@ def merge(releases, schema=None):
     return unflatten(merged)
 
 
-def merge_versioned(releases, schema=None):
+def merge_versioned(releases, schema=None, merge_rules=None):
     ''' Takes a list of releases and merge them making a
     versionedRelease suitible for an OCDS Record '''
-    merge_rules = process_schema(schema)
+    if not merge_rules:
+        merge_rules = process_schema(schema)
     merged = collections.OrderedDict()
     for release in sorted(releases, key=lambda rel: rel["date"]):
         release = release.copy()


### PR DESCRIPTION
`process_schema` takes most of the time of merge process, and It's quite slow. So, it's make sense to move it up, and reduce number of calls to it.