### PR TITLE
Add MissingDateKeyError and NullDateValueError exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.2
 
+### Changed
+
+* If there is more than one release, but the `date` field is missing or null, the `MissingDateKeyError` and `NullDateValueError` exceptions are raised, respestively, instead of the generic `KeyError` and `TypeError`.
+
 ### Fixed
 
 * If a field's value is set to `null`, it is omitted from the compiled release.

--- a/ocdsmerge/merge.py
+++ b/ocdsmerge/merge.py
@@ -344,11 +344,12 @@ def merge_versioned(releases, schema=None, merge_rules=None):
         release = release.copy()
 
         # Don't version the OCID.
-        ocid = release.pop('ocid')
+        ocid = release.pop('ocid', None)
         merged[('ocid',)] = ocid
 
-        releaseID = release['id']
-        date = release['date']
+        # `id` and `date` are required fields, but the data can be invalid.
+        releaseID = release.get('id')
+        date = release.get('date')
         # Prior to OCDS 1.1.4, `tag` didn't set "omitWhenMerged": true.
         tag = release.pop('tag', None)
 

--- a/ocdsmerge/merge.py
+++ b/ocdsmerge/merge.py
@@ -31,6 +31,18 @@ class IdDict(OrderedDict):
         self._identifier = identifier
 
 
+class OCDSMergeError(Exception):
+    """Base class for exceptions from within this package"""
+
+
+class MissingDateKeyError(OCDSMergeError):
+    """Raised when a release is missing a 'date' key"""
+
+
+class NullDateValueError(OCDSMergeError):
+    """Raised when a release has a null 'date' value"""
+
+
 @lru_cache()
 def get_tags():
     """
@@ -274,6 +286,20 @@ def process_flattened(flattened):
     return processed
 
 
+def sorted_releases(releases):
+    """
+    Sorts a list of releases by date.
+    """
+    if len(releases) == 1:
+        return releases
+    try:
+        return sorted(releases, key=lambda release: release['date'])
+    except KeyError:
+        raise MissingDateKeyError
+    except TypeError:
+        raise NullDateValueError
+
+
 def merge(releases, schema=None, merge_rules=None):
     """
     Merges a list of releases into a compiledRelease.
@@ -282,11 +308,12 @@ def merge(releases, schema=None, merge_rules=None):
         merge_rules = get_merge_rules(schema)
 
     merged = OrderedDict({('tag',): ['compiled']})
-    for release in sorted(releases, key=lambda release: release['date']):
+    for release in sorted_releases(releases):
         release = release.copy()
 
-        ocid = release['ocid']
-        date = release['date']
+        # `ocid` and `date` are required fields, but the data can be invalid.
+        ocid = release.get('ocid')
+        date = release.get('date')
         # Prior to OCDS 1.1.4, `tag` didn't set "omitWhenMerged": true.
         release.pop('tag', None)  # becomes ["compiled"]
 
@@ -313,7 +340,7 @@ def merge_versioned(releases, schema=None, merge_rules=None):
         merge_rules = get_merge_rules(schema)
 
     merged = OrderedDict()
-    for release in sorted(releases, key=lambda release: release['date']):
+    for release in sorted_releases(releases):
         release = release.copy()
 
         # Don't version the OCID.

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -24,7 +24,7 @@ from jsonschema import FormatChecker
 from jsonschema.validators import Draft4Validator as validator
 
 from ocdsmerge import merge, merge_versioned, get_merge_rules
-from ocdsmerge.merge import get_tags, get_release_schema_url, flatten, process_flattened
+from ocdsmerge.merge import get_tags, get_release_schema_url, flatten, process_flattened, MissingDateKeyError, NullDateValueError
 
 tags = {
     '1.0': '1__0__3',
@@ -62,6 +62,24 @@ def custom_warning_formatter(message, category, filename, lineno, line=None):
 
 
 warnings.formatwarning = custom_warning_formatter
+
+
+def test_missing_date_key_error():
+    with pytest.raises(MissingDateKeyError):
+        merge([{}, {}])
+
+
+def test_missing_date_key_error_with_one_release():
+    merge([{}])
+
+
+def test_null_date_value_error():
+    with pytest.raises(NullDateValueError):
+        merge([{'date': '2010-01-01'}, {'date': None}])
+
+
+def test_null_date_value_error_with_one_release():
+    merge([{'date': None}])
 
 
 @pytest.mark.parametrize('filename,schema', test_merge_argvalues)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -68,19 +68,39 @@ warnings.formatwarning = custom_warning_formatter
 def test_missing_date_key_error():
     with pytest.raises(MissingDateKeyError):
         merge([{}, {}])
+    with pytest.raises(MissingDateKeyError):
+        merge_versioned([{}, {}])
 
 
 def test_missing_date_key_error_with_one_release():
-    merge([{}])
+    assert merge([{}]) == {'id': 'None-None', 'tag': ['compiled']}
+    assert merge_versioned([{'initiationType': 'tender'}]) == {
+        'initiationType': [{
+            'releaseID': None,
+            'releaseDate': None,
+            'releaseTag': None,
+            'value': 'tender',
+        }],
+    }
 
 
 def test_null_date_value_error():
     with pytest.raises(NullDateValueError):
         merge([{'date': '2010-01-01'}, {'date': None}])
+    with pytest.raises(NullDateValueError):
+        merge_versioned([{'date': '2010-01-01'}, {'date': None}])
 
 
 def test_null_date_value_error_with_one_release():
-    merge([{'date': None}])
+    assert merge([{'date': None}]) == {'id': 'None-None', 'tag': ['compiled']}
+    assert merge_versioned([{'date': None, 'initiationType': 'tender'}]) == {
+        'initiationType': [{
+            'releaseID': None,
+            'releaseDate': None,
+            'releaseTag': None,
+            'value': 'tender',
+        }],
+    }
 
 
 @pytest.mark.parametrize('filename,schema', test_merge_argvalues)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -65,35 +65,21 @@ def custom_warning_formatter(message, category, filename, lineno, line=None):
 warnings.formatwarning = custom_warning_formatter
 
 
-def test_missing_date_key_error():
-    with pytest.raises(MissingDateKeyError):
-        merge([{}, {}])
-    with pytest.raises(MissingDateKeyError):
-        merge_versioned([{}, {}])
+@pytest.mark.parametrize('error, data', [(MissingDateKeyError, {}), (NullDateValueError, {'date': None})])
+def test_date_errors(error, data):
+    for method in (merge, merge_versioned):
+        with pytest.raises(error):
+            method([{'date': '2010-01-01'}, data])
 
-
-def test_missing_date_key_error_with_one_release():
-    assert merge([{}]) == {'id': 'None-None', 'tag': ['compiled']}
-    assert merge_versioned([{'initiationType': 'tender'}]) == {
-        'initiationType': [{
-            'releaseID': None,
-            'releaseDate': None,
-            'releaseTag': None,
-            'value': 'tender',
-        }],
+    release = deepcopy(data)
+    assert merge([release]) == {
+        'id': 'None-None',
+        'tag': ['compiled'],
     }
 
-
-def test_null_date_value_error():
-    with pytest.raises(NullDateValueError):
-        merge([{'date': '2010-01-01'}, {'date': None}])
-    with pytest.raises(NullDateValueError):
-        merge_versioned([{'date': '2010-01-01'}, {'date': None}])
-
-
-def test_null_date_value_error_with_one_release():
-    assert merge([{'date': None}]) == {'id': 'None-None', 'tag': ['compiled']}
-    assert merge_versioned([{'date': None, 'initiationType': 'tender'}]) == {
+    release = deepcopy(data)
+    release['initiationType'] = 'tender'
+    assert merge_versioned([release]) == {
         'initiationType': [{
             'releaseID': None,
             'releaseDate': None,

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -24,7 +24,8 @@ from jsonschema import FormatChecker
 from jsonschema.validators import Draft4Validator as validator
 
 from ocdsmerge import merge, merge_versioned, get_merge_rules
-from ocdsmerge.merge import get_tags, get_release_schema_url, flatten, process_flattened, MissingDateKeyError, NullDateValueError
+from ocdsmerge.merge import (get_tags, get_release_schema_url, flatten, process_flattened, MissingDateKeyError,
+                             NullDateValueError)
 
 tags = {
     '1.0': '1__0__3',


### PR DESCRIPTION
If there is more than one release, but the `date` field is missing or null, the `MissingDateKeyError` and `NullDateValueError` exceptions are raised, respestively, instead of the generic `KeyError` and `TypeError`.

closes #21 